### PR TITLE
re #5 fix #5 Changing the call of os.path.mkdir to os.makedirs

### DIFF
--- a/local.py
+++ b/local.py
@@ -18,7 +18,7 @@ def gen_filelist():
     try:
         open(cachefile, 'w').write(files)
     except:
-        os.path.mkdir(lndir)
+        os.makedirs(lndir)
         open(cachefile, 'w').write(files)
     return local_files
 


### PR DESCRIPTION
os.path.mkdir does not exist and should be replaced with `os.makedirs`
